### PR TITLE
fix: deduplicate toast notifications via centralized wrappers

### DIFF
--- a/src/config/axios.js
+++ b/src/config/axios.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 
 const instance = axios.create({
   baseURL: import.meta.env.VITE_BACKEND_URL,

--- a/src/context/authContext.jsx
+++ b/src/context/authContext.jsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useState } from "react";
 import { getMe, signOut as signOutService } from "../services/UserService";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 export const authContext = createContext();
 
 export const useAuth = () => {

--- a/src/lib/sonner-toast.js
+++ b/src/lib/sonner-toast.js
@@ -1,0 +1,24 @@
+import { toast as baseToast } from "sonner";
+
+// Equivalente al wrapper de react-toastify pero para sonner, que deduplica por
+// la opción `id` (si ya existe un toast con ese id, lo actualiza en lugar de
+// crear otro). Evita duplicados de los toasts disparados dentro de useEffect,
+// que StrictMode ejecuta dos veces en desarrollo.
+const deriveId = (message) =>
+  typeof message === "string" || typeof message === "number"
+    ? `toast:${message}`
+    : undefined;
+
+const wrap = (fn) => (message, options) =>
+  fn(message, { id: deriveId(message), ...options });
+
+export const toast = Object.assign(wrap(baseToast), baseToast, {
+  success: wrap(baseToast.success),
+  error: wrap(baseToast.error),
+  info: wrap(baseToast.info),
+  warning: wrap(baseToast.warning),
+  loading: wrap(baseToast.loading),
+  message: wrap(baseToast.message),
+});
+
+export default toast;

--- a/src/lib/toast.js
+++ b/src/lib/toast.js
@@ -1,0 +1,28 @@
+import { toast as baseToast } from "react-toastify";
+
+// Deriva un id estable a partir del contenido del mensaje. Al pasarle un
+// `toastId` fijo, react-toastify deduplica automáticamente: si ya hay un toast
+// activo con ese id, no crea uno nuevo. Esto evita los toasts duplicados que
+// aparecen cuando un toast se dispara dentro de un useEffect, ya que en modo
+// desarrollo StrictMode ejecuta los efectos dos veces (y, en general, ante
+// cualquier re-ejecución del efecto).
+const deriveId = (content) =>
+  typeof content === "string" || typeof content === "number"
+    ? `toast:${content}`
+    : undefined;
+
+const wrap = (fn) => (content, options) =>
+  fn(content, { toastId: deriveId(content), ...options });
+
+// Mantiene toda la API original (dismiss, update, promise, isActive, etc.) y
+// sólo envuelve los métodos que crean toasts para inyectarles el id derivado.
+export const toast = Object.assign(wrap(baseToast), baseToast, {
+  success: wrap(baseToast.success),
+  error: wrap(baseToast.error),
+  info: wrap(baseToast.info),
+  warn: wrap(baseToast.warn),
+  warning: wrap(baseToast.warning),
+  loading: wrap(baseToast.loading),
+});
+
+export default toast;

--- a/src/modules/admin/category/components/CategoryTable.jsx
+++ b/src/modules/admin/category/components/CategoryTable.jsx
@@ -2,7 +2,7 @@ import { Eye, EyeOff } from "lucide-react";
 import { FaEdit } from "react-icons/fa";
 import Swal from "sweetalert2";
 import { useNavigate } from "react-router-dom";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 import {
   deleteCategory,
   updateCategory,

--- a/src/modules/admin/components/app-sidebar-admin.jsx
+++ b/src/modules/admin/components/app-sidebar-admin.jsx
@@ -7,7 +7,7 @@ import { FaUserAlt, FaUsers } from "react-icons/fa";
 import { BsStars } from "react-icons/bs";
 import { useAuth } from "../../../context/authContext";
 import { signOut as signOutService } from "../../../services/UserService";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 import { Sidebar } from "../../../components/ui/sidebar";
 
 export function AppSidebarAdmin({ ...props }) {

--- a/src/modules/admin/components/area-charts.jsx
+++ b/src/modules/admin/components/area-charts.jsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useMemo, useRef } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "../../../components/ui/card";
-import { toast } from "sonner";
+import { toast } from "@/lib/sonner-toast";
 import { Badge } from "../../../components/ui/badge";
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "../../../components/ui/chart";
 import { MultiSelect } from "../../../components/multi-select";

--- a/src/modules/admin/components/radar-charts.jsx
+++ b/src/modules/admin/components/radar-charts.jsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useRef } from "react";
 import { TrendingUp, TrendingDown } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/sonner-toast";
 import { PolarAngleAxis, PolarGrid, Radar, RadarChart } from "recharts";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";

--- a/src/modules/admin/components/radial-charts.jsx
+++ b/src/modules/admin/components/radial-charts.jsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import { TrendingUp, TrendingDown } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/sonner-toast";
 import { PolarGrid, RadialBar, RadialBarChart, ResponsiveContainer } from "recharts";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "../../../components/ui/card";
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "../../../components/ui/chart";

--- a/src/modules/admin/components/recent-sales-card.jsx
+++ b/src/modules/admin/components/recent-sales-card.jsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useState, useRef } from "react";
 import NiceAvatar, { genConfig } from "react-nice-avatar";
 import { SlOptions } from "react-icons/sl";
-import { toast } from "sonner";
+import { toast } from "@/lib/sonner-toast";
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuCheckboxItem } from "../../../components/ui/dropdown-menu";
 import { Button } from "../../../components/ui/button";
 import { Skeleton } from "../../../components/ui/skeleton";

--- a/src/modules/admin/components/section-cards.jsx
+++ b/src/modules/admin/components/section-cards.jsx
@@ -1,7 +1,7 @@
 "use client";
 import { IoMdTrendingUp, IoMdTrendingDown, IoMdCash, IoIosArchive } from "react-icons/io";
 import { FaRegHeart, FaOpencart } from "react-icons/fa";
-import { toast } from "sonner";
+import { toast } from "@/lib/sonner-toast";
 import { useEffect, useState, useRef } from "react";
 import { cn } from "../../../lib/utils";
 import { Skeleton } from "../../../components/ui/skeleton";

--- a/src/modules/admin/forecasting/components/category-forecast.jsx
+++ b/src/modules/admin/forecasting/components/category-forecast.jsx
@@ -7,7 +7,7 @@ import {
     CardContent,
     CardTitle,
 } from "../../../../components/ui/card";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 import { Skeleton } from "../../../../components/ui/skeleton";
 import {
     getForecastCategory,

--- a/src/modules/admin/forecasting/components/product-forecast.jsx
+++ b/src/modules/admin/forecasting/components/product-forecast.jsx
@@ -11,7 +11,7 @@ import { Skeleton } from "../../../../components/ui/skeleton";
 import { getForecastProduct, getPrescriptiveProduct } from "../../../../services/SalesService";
 import TypingText from "./typing-text";
 import { getProductAll } from "../../../../services/ProductService";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 import {
     ResponsiveContainer,
     AreaChart,

--- a/src/modules/admin/product/components/ProductForm.jsx
+++ b/src/modules/admin/product/components/ProductForm.jsx
@@ -9,7 +9,7 @@ import { getCategoryAll as getCategoriesService } from "../../../../services/Cat
 import { getSupplierAll as getSuppliersService } from "../../../../services/SupplierService";
 import { getTagAll as getTagsService } from "../../../../services/TagService";
 import { RiQrScan2Line } from "react-icons/ri";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 
 const isFieldDisable = (isEditMode) => isEditMode;
 const SOCKET_SERVER_URL = import.meta.env.VITE_BARCODE_URL;

--- a/src/modules/admin/product/components/ProductTable.jsx
+++ b/src/modules/admin/product/components/ProductTable.jsx
@@ -8,7 +8,7 @@ import {
   updateProduct,
   enableProduct,
 } from "../../../../services/ProductService";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 
 const ProductTable = ({
   index,

--- a/src/modules/admin/sales/components/FilterModal.jsx
+++ b/src/modules/admin/sales/components/FilterModal.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import Button from "../../../../components/Button";
-import { toast } from "sonner";
+import { toast } from "@/lib/sonner-toast";
 
 const modalBackgroundVariants = {
     hidden: { opacity: 0 },

--- a/src/modules/admin/sales/components/ModalRegisterClient.jsx
+++ b/src/modules/admin/sales/components/ModalRegisterClient.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 import { createClient } from "../../../../services/ClientService"; 
 import TextField from "../../../../components/TextField";
 import Button from "../../../../components/Button";

--- a/src/modules/admin/supplier/components/SupplierTable.jsx
+++ b/src/modules/admin/supplier/components/SupplierTable.jsx
@@ -3,7 +3,7 @@ import { FaEdit } from "react-icons/fa";
 import Swal from "sweetalert2";
 import { useNavigate } from "react-router-dom";
 import { deleteSupplier, updateSupplier } from "../../../../services/SupplierService";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 
 const SupplierTable = ({ index, id, name, phone, email, status, refreshList }) => {
     const navigate = useNavigate();

--- a/src/modules/admin/user/components/UserTable.jsx
+++ b/src/modules/admin/user/components/UserTable.jsx
@@ -2,7 +2,7 @@ import { PiEyeSlash } from "react-icons/pi";
 import { FaEdit } from "react-icons/fa";
 import { Eye, EyeOff } from "lucide-react";
 import Swal from "sweetalert2";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 import "react-toastify/dist/ReactToastify.css";
 import { useNavigate } from "react-router-dom";
 import { updateUser } from "../../../../services/UserService";

--- a/src/modules/clients/components/CategorySection.jsx
+++ b/src/modules/clients/components/CategorySection.jsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from "react";
 import CategoryCard from "./CategoryCard";
 import { getCategoryAll } from "../../../services/CategoryService";
 import { filterProduct } from "../../../services/ProductService";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 import { Link } from "react-router-dom";
 import { Skeleton } from "@/components/ui/skeleton";
 

--- a/src/modules/clients/components/Footer.jsx
+++ b/src/modules/clients/components/Footer.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { getCategoryAll } from "../../../services/CategoryService";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 import { Link } from "react-router-dom";
 
 const Footer = () => {

--- a/src/modules/clients/components/PurchaseTable.jsx
+++ b/src/modules/clients/components/PurchaseTable.jsx
@@ -5,7 +5,7 @@ import { useEffect } from "react";
 import { generatePdf } from "../../../services/SalesService";
 import { getSalesUser } from "../../../services/SalesService";
 import Pagination from "../../../components/Pagination";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 
 export default function PurchaseTable({ purchases }) {
   const [calculatedPurchases, setCalculatedPurchases] = useState([]);

--- a/src/modules/clients/components/VerifyModal.jsx
+++ b/src/modules/clients/components/VerifyModal.jsx
@@ -1,7 +1,7 @@
 import { sendCodeVerification } from "../../../services/ClientService";
 import gsap from "gsap";
 import { useEffect, useRef, useState } from 'react';
-import { toast } from 'react-toastify';
+import { toast } from "@/lib/toast";
 import { motion, AnimatePresence } from "framer-motion";
 
 // Variantes de animación

--- a/src/modules/employees/components/app-sidebar-employee.jsx
+++ b/src/modules/employees/components/app-sidebar-employee.jsx
@@ -6,7 +6,7 @@ import { FaUserAlt } from "react-icons/fa";
 import { BsStars } from "react-icons/bs";
 import { useAuth } from "../../../context/authContext";
 import { signOut as signOutService } from "../../../services/UserService";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 import { Sidebar } from "../../../components/ui/sidebar";
 
 export function AppSidebarEmployee({ ...props }) {

--- a/src/pages/batch/BatchList.jsx
+++ b/src/pages/batch/BatchList.jsx
@@ -9,7 +9,7 @@ import {
   getBatchesByProductId,
   searchBatchByNumber,
 } from "../../services/BatchService.js";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 import { useNavigate } from "react-router-dom";
 import { IoIosArrowDown, IoIosArrowUp } from "react-icons/io";
 import FilterStatus from "../../components/FilterStatus";

--- a/src/pages/batch/BatchRegister.jsx
+++ b/src/pages/batch/BatchRegister.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useParams } from "react-router-dom";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 import Loading from "../../components/Loading";
 import { createBatch } from "../../services/BatchService";
 import { searchProductByNameOrId } from "../../services/ProductService";

--- a/src/pages/category/CategoryList.jsx
+++ b/src/pages/category/CategoryList.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import SearchBar from "../../components/SearchBar.jsx";
 import Button from "../../components/Button.jsx";
 import Pagination from "../../components/Pagination.jsx";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 import { useNavigate } from "react-router-dom";
 import { IoIosArrowDown, IoIosArrowUp } from "react-icons/io";
 import {

--- a/src/pages/category/CategoryRegister.jsx
+++ b/src/pages/category/CategoryRegister.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 import "react-toastify/dist/ReactToastify.css";
 import { createCategory } from "../../services/CategoryService";
 import AdminLayout from "../../modules/admin/layouts/AdminLayout";

--- a/src/pages/category/CategoryUpdate.jsx
+++ b/src/pages/category/CategoryUpdate.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 import AdminLayout from "../../modules/admin/layouts/AdminLayout";
 import "react-toastify/dist/ReactToastify.css";
 import { updateCategory } from "../../services/CategoryService";

--- a/src/pages/login/Login.jsx
+++ b/src/pages/login/Login.jsx
@@ -3,7 +3,7 @@ import { useAuth } from "../../context/authContext";
 import { getAccessToken } from "../../services/FactusService"
 import { useNavigate } from "react-router-dom";
 import { login as loginService } from "../../services/UserService";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 import TextField from "../../components/TextField";
 import PasswordField from "../../components/PasswordField";
 import Button from "../../components/Button";

--- a/src/pages/login/ModalResetPassword.jsx
+++ b/src/pages/login/ModalResetPassword.jsx
@@ -2,7 +2,7 @@
 import React, { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { forgotPassword as forgotPasswordService } from "../../services/UserService";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 import ModalSendReset from "../../components/ModalSendReset";
 import ModalResetPasswordField from "../../components/ModalResetPasswordField";
 

--- a/src/pages/login/ResetPassword.jsx
+++ b/src/pages/login/ResetPassword.jsx
@@ -5,7 +5,7 @@ import Button from "../../components/Button";
 import AuthSidebar from "../../components/AuthSidebar";
 import { setPassword as setPasswordService } from "../../services/UserService";
 import { signOut as signOutService } from "../../services/UserService";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 
 const ResetPassword = () => {
   const [user, setUser] = useState({

--- a/src/pages/products/ProductDetail.jsx
+++ b/src/pages/products/ProductDetail.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 import AdminLayout from "../../modules/admin/layouts/AdminLayout";
 import ProductInfo from "../../modules/admin/product/components/ProductInfo";
 

--- a/src/pages/products/ProductList.jsx
+++ b/src/pages/products/ProductList.jsx
@@ -8,7 +8,7 @@ import {
   getProductAll,
   searchProductByName,
 } from "../../services/ProductService";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 import { useNavigate } from "react-router-dom";
 import { IoIosArrowDown, IoIosArrowUp } from "react-icons/io";
 import FilterStatus from "../../components/FilterStatus";

--- a/src/pages/products/ProductRegister.jsx
+++ b/src/pages/products/ProductRegister.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 import { createProduct as createProductService } from "../../services/ProductService";
 import AdminLayout from "../../modules/admin/layouts/AdminLayout";
 import ProductForm from "../../modules/admin/product/components/ProductForm";

--- a/src/pages/products/ProductUpdate.jsx
+++ b/src/pages/products/ProductUpdate.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useRef } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 import AdminLayout from "../../modules/admin/layouts/AdminLayout";
 import ProductForm from "../../modules/admin/product/components/ProductForm";
 import Loading from "../../components/Loading";

--- a/src/pages/sales/SalesList.jsx
+++ b/src/pages/sales/SalesList.jsx
@@ -12,7 +12,7 @@ import { getSalesFiltered } from "../../services/SalesService";
 import FilterRepaid from "../../components/FilterRepaid";
 import { IoIosArrowDown, IoIosArrowUp } from "react-icons/io";
 import { FaFilter } from "react-icons/fa";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 
 
 const SalesList = () => {

--- a/src/pages/sales/SalesRegister.jsx
+++ b/src/pages/sales/SalesRegister.jsx
@@ -12,7 +12,7 @@ import ProductDeleteModal from "../../modules/admin/sales/components/ModalDelete
 import ModalQR from "../../modules/admin/sales/components/ModalQR";
 import SearchBar from "../../components/SearchBar";
 import Button from "../../components/Button";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 import { getProductForSale } from "../../services/ProductService";
 import { getClientAll } from "../../services/ClientService";
 import { createSale } from "../../services/SalesService";

--- a/src/pages/sales/SalesReturn.jsx
+++ b/src/pages/sales/SalesReturn.jsx
@@ -11,7 +11,7 @@ import { getSalesId } from "../../services/SalesService";
 import Button from "../../components/Button";
 import { returnSale, updateSale } from "../../services/SalesService";
 import { sendCreditNote } from "../../modules/admin/sales/components/invoice/credit_note/sendCreditNote"
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 import 'react-toastify/dist/ReactToastify.css';
 
 

--- a/src/pages/supplier/SupplierList.jsx
+++ b/src/pages/supplier/SupplierList.jsx
@@ -5,7 +5,7 @@ import Button from "../../components/Button";
 import Pagination from "../../components/Pagination";
 import SupplierTable from "../../modules/admin/supplier/components/SupplierTable.jsx";
 import { getSupplierAll, searchSupplier } from "../../services/SupplierService";
-import { toast } from 'react-toastify';
+import { toast } from "@/lib/toast";
 import { useNavigate } from "react-router-dom";
 import { IoIosArrowDown, IoIosArrowUp } from "react-icons/io";
 import FilterStatus from "../../components/FilterStatus";

--- a/src/pages/supplier/SupplierRegister.jsx
+++ b/src/pages/supplier/SupplierRegister.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 import AdminLayout from "../../modules/admin/layouts/AdminLayout";
 import SupplierForm from "../../modules/admin/supplier/components/SupplierForm";
 import { createSupplier } from "../../services/SupplierService";

--- a/src/pages/supplier/SupplierUpdate.jsx
+++ b/src/pages/supplier/SupplierUpdate.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 import AdminLayout from "../../modules/admin/layouts/AdminLayout";
 import SupplierForm from "../../modules/admin/supplier/components/SupplierForm";
 import "react-toastify/dist/ReactToastify.css";

--- a/src/pages/user/UserList.jsx
+++ b/src/pages/user/UserList.jsx
@@ -5,7 +5,7 @@ import Button from "../../components/Button";
 import UserTable from "../../modules/admin/user/components/UserTable.jsx";
 import Pagination from "../../components/Pagination";
 import { getUserAll, searchUser } from "../../services/UserService";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 import { useNavigate } from "react-router-dom";
 import { IoIosArrowDown, IoIosArrowUp } from "react-icons/io";
 import FilterStatus from "../../components/FilterStatus";

--- a/src/pages/user/UserRegister.jsx
+++ b/src/pages/user/UserRegister.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 import { signUp } from "../../services/UserService";
 import AdminLayout from "../../modules/admin/layouts/AdminLayout";
 import UserForm from "../../modules/admin/user/components/UserForm";

--- a/src/pages/user/UserUpdate.jsx
+++ b/src/pages/user/UserUpdate.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { toast } from "react-toastify";
+import { toast } from "@/lib/toast";
 import AdminLayout from "../../modules/admin/layouts/AdminLayout";
 import UserForm from "../../modules/admin/user/components/UserForm";
 import Loading from "../../components/Loading";


### PR DESCRIPTION
## Problema

Varios toasts aparecían **dos veces**. La causa: la app está envuelta en `<StrictMode>` (`src/main.jsx`), que en desarrollo ejecuta los `useEffect` dos veces. Cualquier `toast` disparado dentro de un efecto (errores al cargar listados, gráficas del dashboard, `fetchUser` en `authContext`, etc.) se mostraba duplicado. Los toasts dentro de *handlers* (p. ej. el login) salían una sola vez. No era un problema de contenedores duplicados: hay un único `ToastContainer` y un único `Toaster`.

## Solución

Se centralizan los toasts en dos wrappers que inyectan un id derivado del contenido del mensaje, para que la librería deduplique automáticamente:

- `src/lib/toast.js` → react-toastify (usa `toastId`)
- `src/lib/sonner-toast.js` → sonner (usa `id`)

Y se enrutan todos los imports de `toast` a través de ellos (43 archivos). Los wrappers conservan la API original (`dismiss`, `update`, `promise`, etc.) y respetan opciones personalizadas. No se tocan `ToastContainer`, `Toaster` ni los imports de CSS.

Esto elimina los duplicados en dev y prod, y blinda el código ante futuros toasts en efectos.

## Verificación

- `npm run build` ✅
- ESLint sin errores nuevos ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)