### PR TITLE
feat(forecast): route AI through backend + faster selectors + UX polish

### DIFF
--- a/src/modules/admin/forecasting/components/ai-assistant.jsx
+++ b/src/modules/admin/forecasting/components/ai-assistant.jsx
@@ -137,7 +137,8 @@ export default function AiAssistant() {
     No respondas preguntas sobre la empresa, como su historia, misión, visión, etc.
     Explica tus respuestas de forma detallada y didáctica: no te limites a dar el dato, desarrolla el razonamiento paso a paso apoyándote en las cifras, tendencias y predicciones del contexto, y cita los números concretos relevantes que respaldan tu conclusión.
     Cuando aplique, añade las implicaciones para el negocio y una recomendación práctica y accionable.
-    Estructura la respuesta para que sea fácil de leer, usando varios párrafos o una lista con viñetas cuando ayude a la claridad.
+    Estructura la respuesta para que sea fácil de leer, usando varios párrafos cuando ayude a la claridad.
+    No uses asteriscos ni símbolos de markdown para dar formato (nada de **negritas**, *cursivas* ni viñetas con *). Escribe en prosa corrida y parafrasea las ideas de forma natural dentro de las oraciones.
     No hagas preguntas de seguimiento.`,
       });
 


### PR DESCRIPTION
## Summary

Frontend work for the forecasting section: moves the AI assistant calls onto the backend, makes the product/category selectors fast and searchable, and polishes the assistant output. The AI now goes through the backend `POST /api/ai/run` endpoint, so the frontend is engine-agnostic (the backend currently runs Claude via AWS Bedrock) and no API keys live in the client.

## Changes

### AI assistant → backend endpoint
- Route the assistant and prescriptive analysis through the backend `/ai/run` endpoint instead of calling an external service directly. Large forecast context is compacted client-side before sending.
- Lazy-load the chat context only on first open, instead of on every page mount.

### Faster forecasting selectors (`perf`)
- Use the lightweight `GET /product/names` and `GET /category/names` endpoints (id + name only) to populate the dropdowns, avoiding the heavy full-entity payloads on page load.
- Replace the product `Select` (≈2000 items rendered at once) with a searchable Popover + Command combobox that filters client-side via `useMemo` and caps rendered options.

### UX polish
- Dedupe categories by name in the selector (the bulk seed produced duplicate names).
- Match the category selector style to the product combobox.
- Instruct the chat assistant to answer in plain prose, avoiding markdown asterisks that rendered as raw `*` in the plain-text chat.

## Notes
No new frontend environment variables. Pairs with backend PR omarmolina23/farmacia_be#126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)