### PR TITLE
fix(sales): barcode scanner matching + return credit note flow

### DIFF
--- a/src/pages/products/RegisterBarcode.jsx
+++ b/src/pages/products/RegisterBarcode.jsx
@@ -57,22 +57,13 @@ export default function RegisterBarcode() {
                 { facingMode: 'environment' },
                 { fps: 10, qrbox: 250 },
                 decoded => {
-                    // 1) Limpiamos el resultado (quitamos comillas, espacios, etc.)
+                    // Registramos el código de barras completo tal como viene
+                    // impreso en el producto (sin recortarlo).
                     const code = decoded.trim().replace(/"/g, '');
-                    console.log("code:", code)
-                    // 2) Si parece un EAN-13 válido, extraemos los dígitos 8–12
-                    let barcodeId = code;
-                    if (/^\d{13}$/.test(code)) {
-                        // slice(7, 12) → empieza en índice 7 (8° dígito) y obtiene 5 caracteres
-                        barcodeId = code.slice(7, 12);
-                        console.log("barcodeId obtenido:", barcodeId)
-                    }
-
-                    // 3) Buscamos en tu lista de productos por ese ID
 
                     sock.emit('scan', {
                         sessionId: session,
-                        productBarcode: barcodeId,
+                        productBarcode: code,
                     });
 
                     playBeep();

--- a/src/pages/sales/SalesReturn.jsx
+++ b/src/pages/sales/SalesReturn.jsx
@@ -9,7 +9,7 @@ import EmployeesLayout from "../../modules/employees/layouts/EmployeeLayout"
 import SalesProduct from "../../modules/admin/sales/components/SalesProduct";
 import { getSalesId } from "../../services/SalesService";
 import Button from "../../components/Button";
-import { returnSale, updateSale } from "../../services/SalesService";
+import { returnSale, generateCreditNote } from "../../services/SalesService";
 import { sendCreditNote } from "../../modules/admin/sales/components/invoice/credit_note/sendCreditNote"
 import { toast } from "@/lib/toast";
 import 'react-toastify/dist/ReactToastify.css';
@@ -120,7 +120,7 @@ const SalesReturn = () => {
                     reference_code: sale.id,
                     productos: productsToReturn,
                 });
-                await updateSale(sale.id, {
+                await generateCreditNote(sale.id, {
                     number_credit_note: response.data.credit_note.number,
                     cufe: response.data.credit_note.cude,
                     qr_image: response.data.credit_note.qr_image,

--- a/src/pages/sales/ScanPage.jsx
+++ b/src/pages/sales/ScanPage.jsx
@@ -65,17 +65,16 @@ export default function ScanPage() {
                 { facingMode: 'environment' },
                 { fps: 10, qrbox: 250 },
                 decoded => {
-                    // 1) Limpiamos el resultado (quitamos comillas, espacios, etc.)
+                    // Limpiamos el resultado (quitamos comillas, espacios, etc.)
                     const code = decoded.trim().replace(/"/g, '');
-                    // 2) Si parece un EAN-13 válido, extraemos los dígitos 8–12
-                    let barcodeId = code;
-                    if (/^\d{13}$/.test(code)) {
-                        // slice(7, 12) → empieza en índice 7 (8° dígito) y obtiene 5 caracteres
-                        barcodeId = code.slice(7, 12);
-                    }
 
-                    // 3) Buscamos en tu lista de productos por ese ID
-                    const found = products.find(p => String(p.barcode) === barcodeId);
+                    // Buscamos primero por el código de barras completo. Si no
+                    // aparece y el código es un EAN-13, probamos con el código
+                    // interno de 5 dígitos (posiciones 8-12) como respaldo.
+                    let found = products.find(p => String(p.barcode) === code);
+                    if (!found && /^\d{13}$/.test(code)) {
+                        found = products.find(p => String(p.barcode) === code.slice(7, 12));
+                    }
 
                     if (found) {
                         setProductFound(found);

--- a/src/services/SalesService.js
+++ b/src/services/SalesService.js
@@ -33,6 +33,22 @@ export const updateSale = async (sale_id, data) => {
 };
 
 
+// Registra los datos de la nota de crédito (devolución) y dispara el envío del
+// correo con el PDF de la nota de crédito, no la factura de venta.
+export const generateCreditNote = async (sale_id, data) => {
+    try {
+        const response = await axios.patch(`/sales/credit-note/${sale_id}`, data);
+        return response.data;
+    } catch (error) {
+        console.error("Error en generateCreditNote:", error.response || error);
+        throw new Error(
+            error.response?.data?.message ||
+            "Ha ocurrido un error al generar la nota de crédito"
+        );
+    }
+};
+
+
 export const returnSale = async (sale_id) => {
     try {
         const response = await axios.patch(`/sales/return/${sale_id}`);


### PR DESCRIPTION
## Summary

Two fixes found while testing on-device.

### Barcode scanner (`fix(scanner)`)
The sales (`ScanPage`) and registration (`RegisterBarcode`) scanners sliced any 13-digit code to its 8th–12th digits before lookup, which never matched the full 13-digit barcodes stored for products — so products could not be found by scanning.
- `ScanPage` now matches by the **full scanned barcode first**, falling back to the 5-digit EAN-13 internal slice only if no product matches (keeps the real-EAN-13 convention working).
- `RegisterBarcode` now emits the **full scanned barcode** so a product is registered with its real code instead of a truncated one.

### Returns / credit note (`fix(sales)`)
The return flow called `updateSale`, which hits the e-invoice endpoint and re-sent the **sale invoice**. It now calls the new credit note endpoint so the credit note data is persisted and the **credit note document** is emailed instead of the original invoice.

Pairs with backend PR omarmolina23/farmacia_be#126 (adds `PATCH /sales/credit-note/:id` and the conditional credit-note template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)